### PR TITLE
Alright, I've made some corrections to how students and teachers are …

### DIFF
--- a/app/api/chat/students/route.ts
+++ b/app/api/chat/students/route.ts
@@ -74,86 +74,117 @@ export async function GET(request: NextRequest) {
       }
     }
     
-    // If no classes found in subjects collection, fall back to user data
-    if (assignedClasses.length === 0) {
-      assignedClasses = userData.assignedClasses || [];
-    }
-    
-    console.log("Teacher subjects from collection:", teacherSubjects);
-    console.log("Assigned classes from collection:", assignedClasses);
-    
-    // Fetch students
+    // The `assignedClasses` variable derived above is a general list of all classes the teacher is associated with.
+    // We will re-evaluate which class IDs to use for student filtering based on the specific subject selected, if any.
+    console.log("Initial teacher subjects for UI filter:", teacherSubjects);
+    // console.log("Initial assigned classes (all subjects) for teacher:", assignedClasses);
+
     const studentsRef = collection(db, "users");
-    let studentsQuery;
-    
-    // If a specific subject is requested, filter by that subject
+    let studentList: any[] = [];
+    let targetClassIds: string[] = [];
+
     if (subject && subject !== "all") {
-      console.log("Filtering students by subject:", subject);
+      console.log(`Filtering students for teacher ${teacherId} and subject: ${subject}`);
       
-      // First, find the class IDs for this subject
-      const subjectClassesQuery = query(
+      // 1. Query 'subjects' collection for teacherId AND subjectName
+      const specificSubjectClassesQuery = query(
         subjectsRef, 
         where("teacherId", "==", teacherId),
         where("subjectName", "==", subject)
       );
+      const specificSubjectClassesSnapshot = await getDocs(specificSubjectClassesQuery);
       
-      const subjectClassesSnapshot = await getDocs(subjectClassesQuery);
-      const subjectClassIds = subjectClassesSnapshot.docs.map(doc => doc.data().classId).filter(Boolean);
-      
-      console.log("Classes for this subject:", subjectClassIds);
-      
-      if (subjectClassIds.length > 0) {
-        // Query students by class IDs
-        studentsQuery = query(
+      // 2. Collect unique classIds from these records
+      const classIdsForSubject = [...new Set(specificSubjectClassesSnapshot.docs.map(doc => doc.data().classId).filter(Boolean))];
+      console.log(`Teacher ${teacherId} teaches subject ${subject} in classIds: ${classIdsForSubject.join(", ") || "None"}`);
+
+      // 3. If no such classIds, return empty list
+      if (classIdsForSubject.length === 0) {
+        console.log(`No classes found where teacher ${teacherId} teaches subject ${subject}. Returning empty student list.`);
+        return NextResponse.json({ students: [], subjects: teacherSubjects });
+      }
+      targetClassIds = classIdsForSubject;
+
+      // 4. Query 'users' for students
+      // Firestore 'in' query limit is 30. Assume targetClassIds won't exceed this for a teacher/subject.
+      if (targetClassIds.length > 0) {
+        const studentsQuery = query(
           studentsRef,
           where("role", "==", "student"),
-          where("grade", "in", subjectClassIds)
-        );
-      } else {
-        // Fallback to enrolled subjects if no classes found
-        studentsQuery = query(
-          studentsRef,
-          where("role", "==", "student"),
+          where("grade", "in", targetClassIds),
+          // 5. Additionally, ensure student is enrolled in the subject
           where("enrolledSubjects", "array-contains", subject)
         );
+        const studentsSnapshot = await getDocs(studentsQuery);
+        console.log(`Found ${studentsSnapshot.size} students in classes [${targetClassIds.join(", ")}] and enrolled in subject ${subject}.`);
+
+        // If the above compound query is too restrictive or not supported perfectly across all Firestore versions/setups for 'in' + 'array-contains'
+        // an alternative is to query by classIds and then filter by enrolledSubjects in code.
+        // For now, we assume the compound query works as intended by Firestore for this specific case.
+        // If issues arise, the filtering step would be:
+        // studentList = studentsSnapshot.docs
+        //   .map(doc => ({ id: doc.id, ...doc.data() }))
+        //   .filter(s => s.enrolledSubjects && s.enrolledSubjects.includes(subject));
+        // console.log(`Filtered down to ${studentList.length} students after checking enrolledSubjects in code.`);
+
+        studentList = studentsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data()}));
+
       }
-    } else {
-      // Otherwise filter by assigned classes
-      if (assignedClasses.length > 0) {
-        console.log("Filtering students by classes:", assignedClasses);
-        studentsQuery = query(
-          studentsRef,
-          where("role", "==", "student"),
-          where("grade", "in", assignedClasses)
-        );
-      } else {
-        // If no classes, get all students
-        console.log("No assigned classes, fetching all students");
-        studentsQuery = query(
-          studentsRef,
-          where("role", "==", "student")
-        );
+
+    } else { // subject is "all" or not provided
+      console.log(`Fetching all students for teacher ${teacherId}`);
+
+      // 1. Query 'subjects' for all records for the teacherId (already done via subjectsSnapshot earlier)
+      // 2. Collect all unique classIds (already done as `assignedClasses` from the initial block, but let's re-derive for clarity or use it)
+      // For clarity, re-derive from the initial full subjectsSnapshot for the teacher
+      const allClassIdsForTeacher = [...new Set(subjectsSnapshot.docs.map(doc => doc.data().classId).filter(Boolean))];
+
+      console.log(`Teacher ${teacherId} teaches in all of these classIds: ${allClassIdsForTeacher.join(", ") || "None"}`);
+
+      // 3. If no such classIds, return empty list
+      if (allClassIdsForTeacher.length === 0) {
+        console.log(`Teacher ${teacherId} is not associated with any classes. Returning empty student list.`);
+        return NextResponse.json({ students: [], subjects: teacherSubjects });
+      }
+      targetClassIds = allClassIdsForTeacher;
+
+      // 4. Query 'users' for students
+      // Firestore 'in' query limit is 30. Assume targetClassIds won't exceed this for a teacher.
+      if (targetClassIds.length > 0) {
+        // Chunking targetClassIds if it can exceed 30
+        const MAX_IN_QUERY_SIZE = 30;
+        for (let i = 0; i < targetClassIds.length; i += MAX_IN_QUERY_SIZE) {
+            const chunkClassIds = targetClassIds.slice(i, i + MAX_IN_QUERY_SIZE);
+            if (chunkClassIds.length === 0) continue;
+
+            const studentsQuery = query(
+                studentsRef,
+                where("role", "==", "student"),
+                where("grade", "in", chunkClassIds)
+            );
+            const studentsSnapshot = await getDocs(studentsQuery);
+            console.log(`Found ${studentsSnapshot.size} students in classes chunk [${chunkClassIds.join(", ")}].`);
+            studentsSnapshot.forEach(doc => studentList.push({ id: doc.id, ...doc.data() }));
+        }
       }
     }
     
-    const studentsSnapshot = await getDocs(studentsQuery);
-    
-    if (studentsSnapshot.empty) {
-      console.log("No students found after filtering");
+    if (studentList.length === 0) {
+      console.log("No students found matching criteria.");
       return NextResponse.json({ 
         students: [],
         subjects: teacherSubjects
       });
     }
     
-    console.log(`Found ${studentsSnapshot.size} students after filtering`);
-    const students = studentsSnapshot.docs.map(doc => ({
-      id: doc.id,
-      name: doc.data().name,
-      class: doc.data().grade || "Unknown Class",
-      rollNumber: doc.data().rollNumber || "N/A",
-      avatar: doc.data().profilePicture || null,
-      subjects: doc.data().enrolledSubjects || []
+    console.log(`Total ${studentList.length} students found after filtering.`);
+    const students = studentList.map(s_data => ({ // Renamed 'data' to 's_data' for clarity
+      id: s_data.id,
+      name: s_data.name,
+      class: s_data.grade || "Unknown Class",
+      rollNumber: s_data.rollNumber || "N/A",
+      avatar: s_data.profilePicture || null,
+      subjects: s_data.enrolledSubjects || []
     }));
 
     console.log("Returning response with subjects:", teacherSubjects);

--- a/app/api/chat/teachers/route.ts
+++ b/app/api/chat/teachers/route.ts
@@ -39,92 +39,106 @@ export async function GET(request: NextRequest) {
       );
     }
     
-    const studentClass = userData.grade || userData.class; // Assuming 'grade' field stores the class ID
+    // Step 1: Fetch Student Data & Validate
+    const studentClassId = userData.grade || userData.class; // Assuming 'grade' field stores the class ID
     const studentEnrolledSubjects = userData.enrolledSubjects;
 
-    if (!studentClass) {
-      console.log(`Student ${userData.name} (${studentId}) does not have class information (grade).`);
-      return NextResponse.json({ error: "Student class information (grade) not found" }, { status: 400 });
+    console.log(`Student Data: ID=${studentId}, Name=${userData.name}, ClassID=${studentClassId}, EnrolledSubjects=${JSON.stringify(studentEnrolledSubjects)}`);
+
+    if (!studentClassId) {
+      console.log(`Student ${userData.name} (${studentId}) does not have class information (grade/classId).`);
+      return NextResponse.json({ teachers: [] }); // Return empty list as per requirement
     }
 
     if (!studentEnrolledSubjects || studentEnrolledSubjects.length === 0) {
       console.log(`Student ${userData.name} (${studentId}) has no enrolled subjects.`);
-      // It's valid for a student to have no enrolled subjects yet, so return empty list of teachers.
-      return NextResponse.json({ teachers: [] });
+      return NextResponse.json({ teachers: [] }); // Return empty list
+    }
+    // Limit studentEnrolledSubjects to 30 for "in" query, though typically a student has fewer.
+    if (studentEnrolledSubjects.length > 30) {
+        console.warn(`Student ${studentId} has ${studentEnrolledSubjects.length} enrolled subjects. Truncating to 30 for query performance.`);
+        studentEnrolledSubjects.splice(30);
     }
 
-    console.log(`Fetching teachers for student ${studentId} in class ${studentClass} and subjects: ${studentEnrolledSubjects.join(", ")}`);
+    console.log(`Processing request for student ${studentId} in class ${studentClassId} for subjects: ${studentEnrolledSubjects.join(", ")}`);
 
-    // Query the 'subjects' collection
+    // Step 2: Query 'subjects' Collection
     const subjectsRef = collection(db, "subjects");
     const subjectsQuery = query(
       subjectsRef,
-      where("classId", "==", studentClass),
+      where("classId", "==", studentClassId),
       where("subjectName", "in", studentEnrolledSubjects)
     );
 
     const subjectsSnapshot = await getDocs(subjectsQuery);
-    console.log(`Found ${subjectsSnapshot.size} subject documents matching student's class and enrolled subjects.`);
+    console.log(`Found ${subjectsSnapshot.size} entries in 'subjects' collection matching student's class and enrolled subjects.`);
 
     if (subjectsSnapshot.empty) {
-      console.log("No relevant subject documents found for the student's criteria.");
+      console.log("No relevant subject entries found linking teachers to this student's class/subjects.");
       return NextResponse.json({ teachers: [] });
     }
 
-    const teacherIds = new Set<string>();
+    // Step 3: Collect Teacher Information (teacherId -> Set<subjectName>)
+    const teacherIdToSubjectsMap = new Map<string, Set<string>>();
     subjectsSnapshot.forEach(doc => {
       const subjectData = doc.data();
-      if (subjectData.teacherId) {
-        teacherIds.add(subjectData.teacherId);
+      const { teacherId, subjectName, classId } = subjectData;
+      console.log(`  Matching subject entry: teacherId=${teacherId}, subjectName=${subjectName}, classId=${classId}`);
+      if (teacherId && subjectName) {
+        if (!teacherIdToSubjectsMap.has(teacherId)) {
+          teacherIdToSubjectsMap.set(teacherId, new Set<string>());
+        }
+        teacherIdToSubjectsMap.get(teacherId)!.add(subjectName);
       }
     });
 
-    if (teacherIds.size === 0) {
-      console.log("No teacherIds found in the relevant subject documents.");
+    const uniqueTeacherIds = Array.from(teacherIdToSubjectsMap.keys());
+    if (uniqueTeacherIds.length === 0) {
+      console.log("No valid teacherIds extracted from subject entries.");
       return NextResponse.json({ teachers: [] });
     }
-    
-    console.log(`Found ${teacherIds.size} unique teacher ID(s): ${Array.from(teacherIds).join(", ")}`);
+    console.log(`Found ${uniqueTeacherIds.length} unique teacher ID(s): ${uniqueTeacherIds.join(", ")}`);
+    console.log("Teacher ID to relevant subjects map:", Object.fromEntries(Array.from(teacherIdToSubjectsMap.entries()).map(([k, v]) => [k, Array.from(v)])));
 
-    // Fetch teacher details from 'users' collection
+
+    // Step 4: Fetch Teacher User Details
     const teachers: any[] = [];
-    // Firestore 'in' query supports up to 30 elements. If more, chunking is needed.
-    // For simplicity, assuming teacherIds.size will be manageable.
-    // If teacherIds.size can be very large, this part needs to be updated to handle >30 IDs.
-    const teacherIdsArray = Array.from(teacherIds);
-    if (teacherIdsArray.length > 0) {
-        // Max 30 items for "in" query in Firestore. Chunk if necessary.
-        const MAX_IN_QUERY_ITEMS = 30;
-        for (let i = 0; i < teacherIdsArray.length; i += MAX_IN_QUERY_ITEMS) {
-            const chunk = teacherIdsArray.slice(i, i + MAX_IN_QUERY_ITEMS);
-            if (chunk.length === 0) continue;
+    const MAX_IN_QUERY_ITEMS = 30; // Firestore 'in' query limit
 
-            const teachersQuery = query(
-                collection(db, "users"),
-                where("__name__", "in", chunk), // Query by document ID
-                where("role", "==", "teacher")
-            );
-            const teachersSnapshot = await getDocs(teachersQuery);
+    for (let i = 0; i < uniqueTeacherIds.length; i += MAX_IN_QUERY_ITEMS) {
+        const chunkTeacherIds = uniqueTeacherIds.slice(i, i + MAX_IN_QUERY_ITEMS);
+        if (chunkTeacherIds.length === 0) continue;
 
-            teachersSnapshot.forEach(doc => {
-                const data = doc.data();
-                console.log(`Fetched teacher: ${data.name}, Role: ${data.role}`);
-                teachers.push({
-                    id: doc.id,
-                    name: data.name,
-                    // The concept of a single "subject" for a teacher is ambiguous here,
-                    // as a teacher can teach multiple subjects.
-                    // For now, we can list their primary subject or just identify them as a teacher.
-                    // Or, more accurately, the client might use the student's subject context.
-                    subject: data.subjects && data.subjects.length > 0 ? data.subjects.join(", ") : "Teacher",
-                    email: data.email || "",
-                    avatar: data.profilePicture || null,
-                });
+        console.log(`Fetching user details for teacher ID chunk: ${chunkTeacherIds.join(", ")}`);
+        const usersQuery = query(
+            collection(db, "users"),
+            where("__name__", "in", chunkTeacherIds), // Query by document ID
+            where("role", "==", "teacher")
+        );
+        const usersSnapshot = await getDocs(usersQuery);
+
+        usersSnapshot.forEach(userDoc => {
+            const teacherData = userDoc.data();
+            const teacherId = userDoc.id;
+            console.log(`  Fetched teacher user: ID=${teacherId}, Name=${teacherData.name}, Role=${teacherData.role}`);
+
+            const relevantSubjectsSet = teacherIdToSubjectsMap.get(teacherId);
+            const relevantSubjectsArray = relevantSubjectsSet ? Array.from(relevantSubjectsSet) : [];
+            // Step 5: Format Response
+            teachers.push({
+                id: teacherId,
+                name: teacherData.name,
+                // Use specific subjects from the map, not teacherData.subjects
+                subject: relevantSubjectsArray.join(", ") || "N/A",
+                email: teacherData.email || "",
+                avatar: teacherData.profilePicture || null,
+                // For debugging, include the list of relevant subjects explicitly if needed
+                // relevantStudentSubjects: relevantSubjectsArray
             });
-        }
+        });
     }
 
-    console.log(`Returning ${teachers.length} teachers for student ${studentId}.`);
+    console.log(`Returning ${teachers.length} formatted teacher object(s) for student ${studentId}.`);
     return NextResponse.json({ teachers });
   } catch (error) {
     console.error("Error fetching teachers:", error);


### PR DESCRIPTION
…listed in the chat backend for you.

This update fixes issues where the teacher's chat page wasn't showing the right students for a selected subject, and similarly, the student's chat page wasn't displaying the correct teachers for their enrolled subjects.

The main adjustments were made to the backend API routes' Firestore query logic:

1.  **For the Teacher's View (Listing Students):**
    *   I've refined how students are fetched for a teacher.
    *   Now, when you select a subject as a teacher, the system correctly identifies the classes where you teach that specific subject.
    *   Then, it finds students who are in those classes and also enrolled in the selected subject.
    *   The "all subjects" view for a teacher now accurately shows all students from all classes you're associated with.
    *   I've removed some previous logic that could lead to incorrect student listings.
    *   I also implemented a more robust way to handle certain database queries.

2.  **For the Student's View (Listing Teachers):**
    *   I've refined how teachers are fetched for a student.
    *   The system now uses your grade and your list of enrolled subjects.
    *   It looks for subjects that match your grade and are in your enrolled subjects list.
    *   From there, it identifies the teachers for those subjects.
    *   Then, it retrieves the full profiles of these teachers.
    *   When you see a teacher in your list, it will now also show the specific subject(s) they teach that are relevant to you.
    *   I've also added some better diagnostic information for this part.

I checked the core messaging logic, and it seems to be working correctly; it just needed the updated listing logic to provide the right user information.

These changes should ensure the backend provides accurate data to the frontend, resolving the issues you noticed with user listings in the chat feature.